### PR TITLE
fix sklearn requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'pytest',
         'requests',
         'shapely>=1.7',
-        'sklearn',
+        'scikit-learn',
         'tqdm',
         'utm'
     ]


### PR DESCRIPTION
scikit-learn is imported as `sklearn` but needs to be installed as `scikit-learn`, otherwise it pulls some random empty package. A quick fix as I just noticed this. 

Also, you have `requirements.txt` that is out of sync with this list, is that on purpose?