### PR TITLE
release: publish curated notes from RELEASE_NOTES.md, not the commit …

### DIFF
--- a/.github/workflows/generate_changelog.yml
+++ b/.github/workflows/generate_changelog.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to generate changelog for (leave empty for latest)"
+        description: "Tag to generate release notes for (leave empty for latest)"
         required: false
         type: string
 permissions:
@@ -35,7 +35,7 @@ jobs:
             echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Generate changelog
+      - name: Generate changelog (fallback for tags without curated notes)
         uses: orhun/git-cliff-action@v4
         id: cliff
         with:
@@ -43,6 +43,22 @@ jobs:
           args: --latest --strip header
         env:
           OUTPUT: CHANGES.md
+
+      - name: Prefer curated notes from RELEASE_NOTES.md
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          # Extract the section headed "# <tag> Release Notes", up to the next version heading.
+          awk -v tag="$TAG" '
+            $0 ~ "^# " tag "([ ]|$)" { found = 1; next }
+            found && /^# v[0-9]/ { found = 0 }
+            found { print }
+          ' RELEASE_NOTES.md > SECTION.md
+          if [ -s SECTION.md ]; then
+            echo "Publishing curated notes from RELEASE_NOTES.md for $TAG"
+            cp SECTION.md CHANGES.md
+          else
+            echo "No RELEASE_NOTES.md section for $TAG; using the generated changelog"
+          fi
 
       - name: Create or update GitHub Release
         uses: softprops/action-gh-release@v2

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+# v5.1.0 Release Notes
+
+A documentation and usability release on top of v5.0.0. No breaking changes.
+
+- **Origin-Destination Flows**: a new guide section, plus recipes covering explicit OD-matrix routing (`build_od_matrix` with `betweenness_od`) and demand-modelled flows (`betweenness_demand`).
+- **Network cleaning guide**: a dedicated section on automated versus configurable cleaning, with references.
+- **Configurable Overpass endpoint**: `fetch_osm_network` and `osm_graph_from_poly` accept an `overpass_url` argument, or the `CITYSEER_OVERPASS_URL` environment variable, plus an optional `cache_path` for offline and repeatable OSM builds.
+- **Restyled example plots**: uniform colour with line width scaled by intensity, no colour bars.
+
 # v5.0.0 Release Notes
 
 ## Headline


### PR DESCRIPTION
…dump

The changelog workflow published git-cliff --latest straight into the GitHub Release body, so releases showed commit subjects (paper and internal refactors) instead of user-facing notes. Extract the section headed '# <tag> Release Notes' from RELEASE_NOTES.md and use that as the release body, falling back to the generated changelog for tags (betas) without a curated section. Add the v5.1.0 section.